### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -87,7 +87,7 @@ class syntax_plugin_doodle3 extends DokuWiki_Syntax_Plugin
      * Handle the match, parse parameters & choices
      * and prepare everything for the render() method.
      */
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         $match = substr($match, 8, -9);              // strip markup (including space after "<doodle ")
         list($parameterStr, $choiceStr) = preg_split('/>/u', $match, 2);
 
@@ -193,7 +193,7 @@ class syntax_plugin_doodle3 extends DokuWiki_Syntax_Plugin
      * add new vote if user just submitted one and
      * create output xHTML from template
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if ($mode != 'xhtml') return false;
         
         //debout("render: $mode");        


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
