### PR TITLE
Add fieldwidth option

### DIFF
--- a/doodle_template.php
+++ b/doodle_template.php
@@ -34,7 +34,7 @@
      <tr class="row1">
          <th class="col0"><?php echo $lang['fullname'] ?></th>
 <?php foreach ($template['choices'] as $choice) {  ?>
-         <td class="centeralign"><?php echo $choice ?></td>
+         <td class="centeralign" style="width:<?php echo $template['fieldwidth'] ?>"><?php echo $choice ?></td>
 <?php } ?>
      </tr>
 

--- a/syntax.php
+++ b/syntax.php
@@ -99,7 +99,8 @@ class syntax_plugin_doodle3 extends DokuWiki_Syntax_Plugin
             'adminGroups'    => '',
             'adminMail'      => null,
             'voteType'       => 'default',
-            'closed'         => FALSE
+            'closed'         => FALSE,
+	    'fieldwidth'     => 'auto'
         );
 
         //----- parse parameteres into name="value" pairs  
@@ -154,7 +155,11 @@ class syntax_plugin_doodle3 extends DokuWiki_Syntax_Plugin
             } else
             if (strcmp($name, "SORT") == 0) {
                 $params['sort'] = $value;  // make it possible to sort by time
-            }
+            } else
+	    if (strcmp($name, "FIELDWITH") == 0) {
+		if (preg_match("/^[0-9]+px$/",$value,$hit) == 1)
+		    $params['fieldwidth'] = $hit[0];
+	    }
         }
 
         // (If there are no choices inside the <doodle> tag, then doodle's data will be reset.)
@@ -284,6 +289,7 @@ class syntax_plugin_doodle3 extends DokuWiki_Syntax_Plugin
         $this->template['result']     = $this->params['closed'] ? $this->getLang('final_result') : $this->getLang('count');
         $this->template['doodleData'] = array();  // this will be filled with some HTML snippets
         $this->template['formId']     = $formId;
+	$this->template['fieldwidth'] = $this->params['fieldwidth'];
         if ($this->params['closed']) {
             $this->template['msg'] = $this->getLang('poll_closed');
         }

--- a/syntax.php
+++ b/syntax.php
@@ -156,7 +156,7 @@ class syntax_plugin_doodle3 extends DokuWiki_Syntax_Plugin
             if (strcmp($name, "SORT") == 0) {
                 $params['sort'] = $value;  // make it possible to sort by time
             } else
-	    if (strcmp($name, "FIELDWITH") == 0) {
+	    if (strcmp($name, "FIELDWIDTH") == 0) {
 		if (preg_match("/^[0-9]+px$/",$value,$hit) == 1)
 		    $params['fieldwidth'] = $hit[0];
 	    }


### PR DESCRIPTION
New param: fieldwidth (optional)
default value: fieldwidth
valid options: column width in px matching the pattern: /^[0-9]+px$/
function: Control the width of the option columns. The css-style "width" is set to the value provided in fieldwidth param. By default this value is set to "auto". Input is validated with preg_match.